### PR TITLE
When minifying the source, an error is introduced.

### DIFF
--- a/writeCapture.js
+++ b/writeCapture.js
@@ -170,7 +170,7 @@
 			try {
 				// just in case there is a bug, always resume 
 				// if paused is less than 1
-				while(this.paused < 1 && this._next());
+				while(this.paused < 1 && this._next()){}
 			} finally {
 				this.running = false;
 			}


### PR DESCRIPTION
When using Packer or other similar minifiers, there is a break in the javascript due to the shorthand method of the while loop on line 173.  I just changed it to the longhand method.
