### PR TITLE
Sojern

### DIFF
--- a/writeCapture.js
+++ b/writeCapture.js
@@ -375,9 +375,9 @@
 			return match[2] || match[3];
 		};
 	}
-	
-	var SCRIPT_TAGS = /(<script[\s\S]*?>)([\s\S]*?)<\/script>/ig, 
-		SCRIPT_2 = /<script[\s\S]*?\/>/ig,
+
+	var SCRIPT_TAGS = /(<script[^>]*>)([\s\S]*?)<\/script>/ig, 
+		SCRIPT_2 = /<script[^>]*\/>/ig,
 		SRC_REGEX = attrPattern('src'),
 		SRC_ATTR = matchAttr('src'),
 		TYPE_ATTR = matchAttr('type'),

--- a/writeCapture.js
+++ b/writeCapture.js
@@ -45,15 +45,21 @@
 			 */
 			replaceWith: function(selector,content) {
 				// jQuery 1.4? has a bug in replaceWith so we can't use it directly
-				var el = jQuery(selector)[0];
+				if(typeof(selector) == "string"){
+				  var el = document.getElementById(selector.replace(/#/,''));
+			  } else {
+				  var el = jQuery(selector)[0];
+				}
 				var next = el.nextSibling, parent = el.parentNode;
 
 				jQuery(el).remove();
 
 				if ( next ) {
 					jQuery(next).before( content );
-				} else {
+				} else if (parent) {
 					jQuery(parent).append( content );
+				} else {
+				  jQuery(el).append( content );
 				}
 			},
 


### PR DESCRIPTION
The first commit fixes a problem with the script search regexes which were a little too greedy. They were picking up some intermediate HTML that was between two script tags.

The second commit is a little strange, and I wanted you to specifically look at it. We had an issue while using jQuery 1.3.2 and writeCapture. The line `var el = jQuery(selector)[0];` in the `replaceWith` function was blowing up when `selector` was a string rather than an element. We aren't sure why - we were able to find the element by using the string. At any rate, we fixed the problem, but I wanted you to look at the code to make sure it was kosher.
