### PR TITLE
Immediate Writes

### DIFF
--- a/writeCapture.js
+++ b/writeCapture.js
@@ -272,7 +272,8 @@
 	function capture(context,options) {
 		var tempEls = [],
 			proxy = getOption('proxyGetElementById',options),
-			writeOnGet = getOption('writeOnGetElementById',options),	
+			writeOnGet = getOption('writeOnGetElementById',options),
+			immediate = getOption('immediateWrites', options),
 			state = {
 				write: doc.write,
 				writeln: doc.writeln,
@@ -280,8 +281,8 @@
 				out: ''
 			};
 		context.state = state;
-		doc.write = replacementWrite;
-		doc.writeln = replacementWriteln;
+		doc.write = immediate ? immediateWrite : replacementWrite;
+		doc.writeln = immediate ? immediateWriteln : replacementWriteln;
 		if(proxy || writeOnGet) {
 			state.getEl = doc.getElementById;
 			doc.getElementById = getEl;
@@ -299,6 +300,14 @@
 		}
 		function replacementWriteln(s) {
 			state.out +=  s + '\n';
+		}
+		function immediateWrite(s) {
+			var target = $.$(context.target);
+			target.parentNode.innerHTML += s;
+		}
+		function immediateWriteln(s) {
+			var target = $.$(context.target);
+			target.parentNode.innerHTML += s + '\n';
 		}
 		function makeTemp(id) {
 			var t = doc.createElement('div');


### PR DESCRIPTION
This is the new functionality to enable immediate writing so scripts can access dom elements that they write in document.write. While the problem seemed to be avoided with the writeOnGetElementById option enabled, I thought this might be nice to have because 1) wiki says use of writeOnGetElementById should be a last resort and has it's own set of problems 2) performance concerns of overriding document.getElementById. From some early testing, it seems the performance gains are only around 4-5% less calls and a couple % off overall run time than using writeOnGetElementById.

I haven't tested it in every case so I'm not sure how it will behave with other options enabled and such, but it seems to be working ok.
