### PR TITLE
Executing js when using immediateWrites

### DIFF
--- a/writeCapture.js
+++ b/writeCapture.js
@@ -303,11 +303,15 @@
 		}
 		function immediateWrite(s) {
 			var target = $.$(context.target);
-			target.parentNode.innerHTML += s;
+			var div = doc.createElement('div');
+			target.parentNode.insertBefore(div,target);
+			$.replaceWith(div,sanitize(s));
 		}
 		function immediateWriteln(s) {
 			var target = $.$(context.target);
-			target.parentNode.innerHTML += s + '\n';
+			var div = doc.createElement('div');
+			target.parentNode.insertBefore(div,target);
+			$.replaceWith(div,sanitize(s) + '\n');
 		}
 		function makeTemp(id) {
 			var t = doc.createElement('div');


### PR DESCRIPTION
Discovered that some of the scripts that were written with immediateWrites option on our site were creating script tags that referenced external js files with document.write. This will allow those to be added to the dom and executed.
