### PR TITLE
nolib fix and IE fix

### DIFF
--- a/support/nolib-support.js
+++ b/support/nolib-support.js
@@ -135,7 +135,7 @@
 				parent = el.parentNode || el.ownerDocument,
 				work = document.createElement('div'),
 				scripts = [],
-				clearHTML = content.replace(/<script([\s\S]*?)>([\S\s]*?)<\/script>/g,function(all,attrs,code) {
+				clearHTML = content.replace(/<script([\s\S]*?)>([\S\s]*?)<\/script>/gi,function(all,attrs,code) {
 					if(isJs(attrs)) {
 						scripts.push(code);
 						return "";						

--- a/writeCapture.js
+++ b/writeCapture.js
@@ -653,6 +653,8 @@
 		var script = document.createElement("script");
 		script.src = url;
 
+		target = $.$(target);
+
 		var done = false, parent = target.parentNode;
 
 		// Attach handlers for all browsers


### PR DESCRIPTION
When using nolib, if scripts in doc.writes don't work since the code is case sensitive.  Just turn on case insensitivity with the regex to fix it.

Didn't bother to investigate further, but it seems IE goes into the code path that excutes doXDomainLoad() with target being a string.  However, the code treats "target" as a DOM object.  The patch turns "target" into an object before using it.
