### PR TITLE
Fix nolib with IE6 and deep copies

### DIFF
--- a/support/nolib-support.js
+++ b/support/nolib-support.js
@@ -144,8 +144,8 @@
 					}
 				});
 			work.innerHTML = clearHTML;
-			for(i = 0, len = work.childNodes.length; i < len; i++) {
-				parent.insertBefore(work.childNodes.item(i).cloneNode(true),el);
+			while (work.firstChild) {
+				parent.insertBefore(work.removeChild(work.firstChild));
 			}
 			parent.removeChild(el);
 			for(i = 0, len = scripts.length; i < len; i++) {


### PR DESCRIPTION
IE6 has issues with cloneNode() where it doesn't do a proper deep copy.  We don't really need to use cloneNode() here, so just use removeChild() instead.

Examples, where cloneNode() doesn't work:

http://blog.pengoworks.com/index.cfm/2007/7/16/IE6--IE7-quirks-with-cloneNode-and-form-elements
http://msdn.microsoft.com/en-us/library/ms536365%28v=vs.85%29.aspx (see comments)

I my case, it was an ad which had an OBJECT with PARAMs in them, where the PARAMs weren't getting copied.  Was working fine when using it with jQuery, but not so with nolib.

Not 100% on the implications of the change, but I believe it should be okay.
