### PR TITLE
Allowing whitespace for DFP

### DIFF
--- a/writeCapture.js
+++ b/writeCapture.js
@@ -395,7 +395,7 @@
 	}
 	
 	function attrPattern(name) {
-		return new RegExp('[\\s\\r\\n]'+name+'\\s?=\\s?(?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
+		return new RegExp('[\\s\\r\\n]'+name+'[\\s\\r\\n]=[\\s\\r\\n](?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
 	}
 	
 	function matchAttr(name) {

--- a/writeCapture.js
+++ b/writeCapture.js
@@ -395,7 +395,7 @@
 	}
 	
 	function attrPattern(name) {
-		return new RegExp('[\\s\\r\\n]'+name+'[\\s\\r\\n]=[\\s\\r\\n](?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
+		return new RegExp('[\\s\\r\\n]'+name+'[\\s\\r\\n]*=[\\s\\r\\n]*(?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
 	}
 	
 	function matchAttr(name) {

--- a/writeCapture.js
+++ b/writeCapture.js
@@ -395,7 +395,7 @@
 	}
 	
 	function attrPattern(name) {
-		return new RegExp('[\\s\\r\\n]'+name+'=(?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
+		return new RegExp('[\\s\\r\\n]'+name+'\\s?=\\s?(?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
 	}
 	
 	function matchAttr(name) {


### PR DESCRIPTION
Hey,
We found an anomalous case when using Google's Doubleclick for Publishers product, which returns tags like this:

```
<script src = "http://etcetc"></script>
```

I've added some optional whitespace to the attribute Regex to allow for this use case. Let me know if you have a better solution or thoughts. 

Thanks,
Matthew 
