### PR TITLE
Often 3rd party markup is being inserted and it is not always valid. Thi...

### DIFF
--- a/writeCapture.js
+++ b/writeCapture.js
@@ -395,7 +395,7 @@
 	}
 	
 	function attrPattern(name) {
-		return new RegExp('[\\s\\r\\n"]'+name+'[\\s\\r\\n]*=[\\s\\r\\n]*(?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
+		return new RegExp('\\b'+name+'[\\s\\r\\n]*=[\\s\\r\\n]*(?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
 	}
 	
 	function matchAttr(name) {

--- a/writeCapture.js
+++ b/writeCapture.js
@@ -395,7 +395,7 @@
 	}
 	
 	function attrPattern(name) {
-		return new RegExp('[\\s\\r\\n]'+name+'[\\s\\r\\n]*=[\\s\\r\\n]*(?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
+		return new RegExp('[\\s\\r\\n"]'+name+'[\\s\\r\\n]*=[\\s\\r\\n]*(?:(["\'])([\\s\\S]*?)\\1|([^\\s>]+))','i');
 	}
 	
 	function matchAttr(name) {


### PR DESCRIPTION
...s allows writeCapture to handle <script type="text/javascript"src="something.js"></script> (note the missing space between attributes) which browsers actually will deal with, but will break the handling of async load callbacks and fail to load the code.
