### PR TITLE
Changed for...in loop in the exec function + queuing error

### DIFF
--- a/writeCapture2.js
+++ b/writeCapture2.js
@@ -174,9 +174,10 @@
 		var doc = getDoc(parent),
 			el = doc.createElement('script'),
 			name, value;
-		for ( var attr in attrs ) {
-			name = attrs[attr].name;
-			value = attrs[attr].value;
+		for ( var i = 0; i < attrs.length; i++ ) {
+			var attr = attrs[i];
+			name = attr.name;
+			value = attr.value;
 
 			if(writerFor.fixUrls && name === 'src') {
 				value = writerFor.fixUrls(value);
@@ -333,7 +334,10 @@
 	function nextWrite() {
 		if(!writing) {
 			var w = queue.shift();
-			if(typeof w.el === 'function') {
+			// End Of Queue
+			if(typeof w === 'undefined' ) {
+				return;
+			} else if(typeof w.el === 'function') {
 				w.el();
 				return;
 			}


### PR DESCRIPTION
Looped the array using the array.length property. This does not loop through any array methods such as those extended by prototype.js

Write Capture 2 has fixed a few bugs but we've been experiencing but I've noticed a few array iteration conflicts if the array class has been extended. I'm aware a few javascript libraries do this (such as prototype) and have converted them to iterate over the array.length property which seems to be functioning fine.

Using the simple API: At the end of the queue javascript would throw an error as 'w.el' was undefined. I've done a quick fix for this by killing the queue if the next thing in the queue is undefined.
